### PR TITLE
Explicitly include `appmap.unittest`

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,10 @@ Setup
 
 1. Download and setup
     1. pipenv install django
-    2. pipenv install appmap
-    3. python manage.py migrate
-    4. pipenv shell
+    1. pipenv install django
+    1. pipenv install appmap
+    1. pipenv shell
+    1. python manage.py migrate
 
 -------------
 

--- a/polls/tests.py
+++ b/polls/tests.py
@@ -1,5 +1,6 @@
 import datetime
 
+import appmap.unittest
 from django.test import TestCase
 from django.urls import reverse
 from django.utils import timezone


### PR DESCRIPTION
@Antylon Until https://github.com/getappmap/appmap-python/issues/197 gets fixed, test files need to import `appmap.unittest` explicitly to ensure that tests get instrumented.

You can now runs tests the Django way, and AppMaps will get generated:

<img width="1842" alt="image" src="https://user-images.githubusercontent.com/4212483/206295157-047b31d3-5f4f-46b9-b65d-5e2b2f072a35.png">

Hope this helps. Let us know if there's anything else we can do.